### PR TITLE
将 webpack 升级到版本3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,49 @@ A parser for fis to compile webpack module.
 
 # [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coverage Status][coverage-image]][coverage-url]
 
+## 使用示例
+
+```js
+fis.match('xx.js', {
+    parser: fis.plugin('webpack', {
+        module: {
+            rules: [{
+                test: /\.css$/,
+                use: [ 'style-loader', 'css-loader' ]
+            }]
+        },
+        // ...options
+        // 请参考 https://webpack.js.org/configuration/#options
+    })
+})
+```
+
+或者
+
+```js
+fis.match('xx.js', {
+    parser: fis.plugin('webpack', {
+        getOptions: function(webpack) {
+            return {
+                module: {
+                    rules: [{
+                        test: /\.css$/,
+                        use: [ 'style-loader', 'css-loader' ]
+                    }]
+                },
+                plugins: [
+                    // Ignore require() calls in vs/language/typescript/lib/typescriptServices.js
+                    new webpack.IgnorePlugin(
+                        /^((fs)|(path)|(os)|(crypto)|(source-map-support))$/,
+                        /vs\/language\/typescript\/lib/
+                    )
+                ]
+            }
+        }
+    })
+})
+```
+
 ## License
 
 MIT © [zswang](http://weibo.com/zswang)

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
  * @author
  *   zswang (http://weibo.com/zswang)
  * @version 0.0.5
- * @date 2016-06-29
+ * @date 2018-03-15
  */
 var webpack = require('webpack');
 var deasync = require('deasync');
@@ -17,33 +17,42 @@ module.exports = function (content, file, conf) {
   var compress = deasync(function (content, callback) {
     var outputFileName = '/output.out';
     var originname = path.resolve(file.origin);
+    if (typeof conf.getOptions === 'function') {
+      conf = conf.getOptions(webpack);
+    }
     var options = {
       entry: originname,
       output: {
-        filename: outputFileName,
+        path: '/',
+        filename: outputFileName.substring(1),
       },
-      path: file.dirname,
-      resolve: conf.resolve,
-      plugins: conf.plugins,
+      // path: file.dirname,  // unknown property
       module: conf.module,
-      hash: false,
-      timings: false,
-      chunks: false,
-      chunkModules: false,
-      modules: false,
-      children: true,
-      version: true,
-      cached: false,
-      cachedAssets: false,
-      reasons: false,
-      source: false,
-      errorDetails: false
+      resolve: conf.resolve,
+      performance: conf.performance,
+      module: conf.module,
+      target: conf.target,
+      externals: conf.externals,
+      plugins: conf.plugins,
+      // hash: false, // unknown property
+      // timings: false, // unknown property
+      // chunks: false, // unknown property
+      // chunkModules: false, // unknown property
+      // modules: false, // unknown property
+      // children: true, // unknown property
+      // version: true, // unknown property
+      // cached: false, // unknown property
+      // cachedAssets: false, // unknown property
+      // reasons: false, // unknown property
+      // source: false, // unknown property
+      // errorDetails: false // unknown property
     };
-    Object.keys(conf).forEach(function (key) {
-      if (typeof options[key] === 'undefined') {
-        options[key] = conf[key];
-      }
-    });
+    // 新版本不识别的字段会报错，所以不能自由添加了。
+    // Object.keys(conf).forEach(function (key) {
+    //   if (typeof options[key] === 'undefined') {
+    //     options[key] = conf[key];
+    //   }
+    // });
     var compiler = webpack(options);
     var mfs = new MemoryFileSystem({});
     mfs.mkdirpSync(path.dirname(originname));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/zswang/fis3-parser-webpack.git"
   },
-  "version": "0.0.5",
+  "version": "0.1.0",
   "main": "lib/index.js",
   "license": "MIT",
   "bugs": {
@@ -17,7 +17,7 @@
     "url": "http://weibo.com/zswang"
   },
   "dependencies": {
-    "webpack": "^1.13.1",
+    "webpack": "^3.4.1",
     "memory-fs": "^0.3.0",
     "proxy-fs": "^0.0.10",
     "deasync": "^0.1.3"

--- a/src/index.js
+++ b/src/index.js
@@ -33,34 +33,47 @@ module.exports = function (content, file, conf) {
   var compress = deasync(function (content, callback) {
     var outputFileName = '/output.out';
     var originname = path.resolve(file.origin);
+
+    if (typeof conf.getOptions === 'function') {
+      conf = conf.getOptions(webpack);
+    }
+
     var options = {
       entry: originname,
       output: {
-        filename: outputFileName,
+        path: '/',
+        filename: outputFileName.substring(1),
       },
-      path: file.dirname,
-      resolve: conf.resolve,
-      plugins: conf.plugins,
+      // path: file.dirname,  // unknown property
       module: conf.module,
-
-      hash: false,
-      timings: false,
-      chunks: false,
-      chunkModules: false,
-      modules: false,
-      children: true,
-      version: true,
-      cached: false,
-      cachedAssets: false,
-      reasons: false,
-      source: false,
-      errorDetails: false
+      resolve: conf.resolve,
+      performance: conf.performance,
+      module: conf.module,
+      target: conf.target,
+      externals: conf.externals,
+      plugins: conf.plugins,
+      
+      // hash: false, // unknown property
+      // timings: false, // unknown property
+      // chunks: false, // unknown property
+      // chunkModules: false, // unknown property
+      // modules: false, // unknown property
+      // children: true, // unknown property
+      // version: true, // unknown property
+      // cached: false, // unknown property
+      // cachedAssets: false, // unknown property
+      // reasons: false, // unknown property
+      // source: false, // unknown property
+      // errorDetails: false // unknown property
     };
-    Object.keys(conf).forEach(function (key) {
-      if (typeof options[key] === 'undefined') {
-        options[key] = conf[key];
-      }
-    });
+    
+    // 新版本不识别的字段会报错，所以不能自由添加了。
+    // Object.keys(conf).forEach(function (key) {
+    //   if (typeof options[key] === 'undefined') {
+    //     options[key] = conf[key];
+    //   }
+    // });
+    
     var compiler = webpack(options);
     var mfs = new MemoryFileSystem({});
     mfs.mkdirpSync(path.dirname(originname));


### PR DESCRIPTION
有部分变动已对应调整。

1. 从 V2 开始，不认识的 options 会报错, 所以注释掉了一堆默认配置。
2. options.out 有变动，filename 只认相对路径，所以这块也改了。
3. 为了配置方便，来了个 conf.getOptions: (webpack:Webpack) => WebPackOptions

另外由于从 webpack 1 一下子升级了到 3 所以，当前包也升级了一个大的版本号。